### PR TITLE
Reduction of Dependencies and Deprecation Warnings

### DIFF
--- a/src/main/java/jpos/config/simple/xml/JavaxRegPopulator.java
+++ b/src/main/java/jpos/config/simple/xml/JavaxRegPopulator.java
@@ -165,8 +165,8 @@ public class JavaxRegPopulator
 
         DOMSource source = new DOMSource(document);
         TransformerFactory factory = TransformerFactory.newInstance();
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "file,jar:file");
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "file,jar:file");
+  //      factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "file,jar:file");
+  //      factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "file,jar:file");
         Transformer transformer = factory.newTransformer();
 
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");

--- a/src/main/java/jpos/config/simple/xml/JavaxRegPopulator.java
+++ b/src/main/java/jpos/config/simple/xml/JavaxRegPopulator.java
@@ -1,0 +1,455 @@
+package jpos.config.simple.xml;
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// This software is provided "AS IS".  The JavaPOS working group (including
+// each of the Corporate members, contributors and individuals)  MAKES NO
+// REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF THE SOFTWARE,
+// EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NON-INFRINGEMENT. The JavaPOS working group shall not be liable for
+// any damages suffered as a result of using, modifying or distributing this
+// software or its derivatives. Permission to use, copy, modify, and distribute
+// the software and its documentation for any purpose is hereby granted.
+//
+// The JavaPOS Config/Loader (aka JCL) is now under the CPL license, which
+// is an OSS Apache-like license.  The complete license is located at:
+//    http://www.ibm.com/developerworks/library/os-cpl.html
+//
+///////////////////////////////////////////////////////////////////////////////
+
+import jpos.config.JposEntry;
+import jpos.config.simple.AbstractRegPopulator;
+import jpos.config.simple.SimpleEntry;
+import jpos.loader.Version;
+import jpos.util.JposEntryUtility;
+import jpos.util.tracing.Tracer;
+import jpos.util.tracing.TracerFactory;
+import org.w3c.dom.*;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.*;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.text.DateFormat;
+import java.util.*;
+
+/**
+ * Simple implementation of the JposRegPopulator that loads and saves
+ * the entries in XML using Javax api.
+ * NOTE: this class must define a public no-argument constructor so that it may be
+ * created via reflection when it is defined in the jpos.properties as
+ * the jpos.config.regPopulatorClass
+ * @see jpos.util.JposProperties#JPOS_REG_POPULATOR_CLASS_PROP_NAME
+ * @since 1.16
+ * @author M. Conrad (martin.conrad@freenet.de)
+ */
+public class JavaxRegPopulator
+        extends AbstractRegPopulator
+        implements XmlRegPopulator
+{
+    /**
+     * Default ctor
+     */
+    public JavaxRegPopulator()
+    { super( JavaxRegPopulator.class.getName() ); }
+
+    /**
+     * 1-arg constructor that takes the unique ID
+     *
+     * @param s the unique ID string
+     * @since 1.3 (Washington DC 2001)
+     */
+    public JavaxRegPopulator( String s )
+    { super(s); }
+
+    //-------------------------------------------------------------------------
+    // Public methods
+    //
+
+    @Override
+    public void save( Enumeration entries )
+            throws Exception
+    {
+        if( isPopulatorFileDefined() )
+            save(entries,  getPopulatorFileOS());
+        else
+            try( FileOutputStream os = new FileOutputStream( "jpos.xml" ) )
+            { save( entries, os ); }
+            catch (Exception e)
+            { throw e; }
+    }
+
+    @Override
+    public void save( Enumeration entries, String fileName )
+            throws Exception
+    {
+        try( FileOutputStream os = new FileOutputStream( fileName ) )
+        { save(entries, os); }
+        catch ( Exception e )
+        { throw e; }
+    }
+
+    @Override
+    public String getClassName() { return JavaxRegPopulator.class.getName(); }
+
+    @Override
+    public void load()
+    {
+        try
+        {
+            //<temp>NEED TO REPLACE WITH A METHOD THAT FIGURES OUT FILE NAME</temp>
+            //<temp>needed to set file name</temp>
+            InputStream is = getPopulatorFileIS();
+            //<temp/>
+            load( getPopulatorFileName() );
+            //<temp/>
+        }
+        catch( Exception e )
+        {
+            tracer.println( "Error while loading populator file Exception.message: " +
+                    e.getMessage() );
+            lastLoadException = e;
+        }
+    }
+
+    @Override
+    public void load( String fileName )
+    {
+        SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+        JavaxSaxHandler saxHandler = new JavaxSaxHandler();
+
+        parserFactory.setNamespaceAware( true );
+        parserFactory.setValidating( true );
+        jposEntryList.clear();
+        try
+        { parserFactory.newSAXParser().parse( new File( fileName ), saxHandler ); }
+        catch (SAXException e)
+        {
+            tracer.println( "SAX Parser error, msg=" + e.getMessage() );
+            lastLoadException = e;
+        }
+        catch ( FileNotFoundException e )
+        {
+            tracer.println( "File not found for " + fileName );
+            lastLoadException = e;
+        }
+        catch ( IOException e )
+        {
+            tracer.println( "XML file access error, msg=" + e.getMessage() );
+            lastLoadException = e;
+        }
+        catch ( ParserConfigurationException e )
+        {
+            tracer.println( "SAX Parser configuration error, msg=" + e.getMessage() );
+            lastLoadException = e;
+        }
+        Iterator entries = jposEntryList.iterator();
+        while( entries.hasNext() )
+        {
+            JposEntry jposEntry = (JposEntry) entries.next();
+            getJposEntries().put( jposEntry.getLogicalName(), jposEntry );
+        }
+    }
+
+    @Override
+    public URL getEntriesURL()
+    {
+        //------------------------------------------------
+        // Copied from AbstractXercesRegPopulator
+        URL url = null;
+
+        if( getPopulatorFileURL() != null &&
+                !getPopulatorFileURL().equals( "" ) )
+            try
+            { url =  new URL( getPopulatorFileURL() ); }
+            catch( Exception e )
+            {
+                tracer.println( "getEntriesURL: Exception.message=" +
+                        e.getMessage() );
+            }
+        else
+            url = createURLFromFile( new File( getPopulatorFileName() ) );
+
+        //<temp>
+        tracer.println( "getPopulatorFileURL()=" + getPopulatorFileURL() );
+        tracer.println( "getPopulatorFileName()=" + getPopulatorFileName() );
+        //</temp>
+
+        return url;
+    }
+
+    @Override
+    public String getName() { return JAVAX_REG_POPULATOR_NAME_STRING; }
+
+    //--------------------------------------------------------------------------
+    // Protected methods
+    //
+
+    /** @return the Tracer object */
+    protected Tracer getTracer() { return tracer; }
+
+    /**
+     * @return a String with the document type definition value.  For DTD this
+     * would be the DTD relative path/file and for schemas the XSD
+     * relative path/file
+     * @since 2.1.0
+     */
+    protected String getDoctypeValue() { return "jpos/res/jcl.dtd"; }
+
+    private void save( Enumeration entries, OutputStream outputStream )
+            throws Exception
+    {
+        Document document = CreateEmptyDocument();
+
+        insertJposEntriesInDoc( entries, document );
+        insertDateSavedComment( document );
+
+        DOMSource source = new DOMSource( document );
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+
+        transformer.setOutputProperty( OutputKeys.INDENT, "yes" );
+        transformer.setOutputProperty( "{http://xml.apache.org/xslt}indent-amount", "4" );
+        transformer.setOutputProperty( OutputKeys.DOCTYPE_PUBLIC, document.getDoctype().getPublicId() );
+        transformer.setOutputProperty( OutputKeys.DOCTYPE_SYSTEM, document.getDoctype().getSystemId() );
+        transformer.transform( source, new StreamResult( outputStream ) );
+    }
+
+    private Document CreateEmptyDocument()
+            throws ParserConfigurationException
+    {
+        DOMImplementation domImpl = DocumentBuilderFactory.newInstance().newDocumentBuilder().getDOMImplementation();
+        DocumentType docType = domImpl.createDocumentType( "JposEntries", "-//JavaPOS//DTD//EN", getDoctypeValue() );
+
+        return domImpl.createDocument(null, "JposEntries", docType);
+    }
+
+    private void insertJposEntriesInDoc( Enumeration entries, Document doc )
+    {
+        while( entries.hasMoreElements() )
+        {
+            JposEntry jposEntry = (JposEntry) entries.nextElement();
+
+            if( JposEntryUtility.isValidJposEntry( jposEntry ) )
+            {
+                Element jposEntryElement = doc.createElement( "JposEntry" );
+
+                jposEntryElement.setAttribute( "logicalName", jposEntry.getLogicalName() );
+                insertJposPropertiesInElement( doc, jposEntry, jposEntryElement );
+                doc.getDocumentElement().appendChild( jposEntryElement );
+            }
+        }
+    }
+
+    private void insertJposPropertiesInElement( Document doc, JposEntry jposEntry, Element jposEntryElement )
+    {
+        Element creation = doc.createElement( "creation" );
+        Element jpos = doc.createElement( "jpos" );
+        Element product = doc.createElement( "product" );
+        Element vendor = doc.createElement( "vendor" );
+
+        for( Element tag : new Element[] { creation, vendor, jpos, product } )
+            jposEntryElement.appendChild(tag);
+
+        List<JposEntry.Prop> sortedProps = getSortedList( jposEntry.getProps() );
+        for( JposEntry.Prop prop : sortedProps )
+        {
+            if( notAttribute( prop, creation, JposEntry.SERVICE_CLASS_PROP_NAME, "serviceClass" ) &&
+                    notAttribute( prop, creation, JposEntry.SI_FACTORY_CLASS_PROP_NAME, "factoryClass" ) &&
+                    notAttribute( prop, vendor, JposEntry.VENDOR_NAME_PROP_NAME, "name" ) &&
+                    notAttribute( prop, vendor, JposEntry.VENDOR_URL_PROP_NAME, "url" ) &&
+                    notAttribute( prop, jpos, JposEntry.JPOS_VERSION_PROP_NAME, "version" ) &&
+                    notAttribute( prop, jpos, JposEntry.DEVICE_CATEGORY_PROP_NAME, "category" ) &&
+                    notAttribute( prop, product, JposEntry.PRODUCT_NAME_PROP_NAME, "name" ) &&
+                    notAttribute( prop, product, JposEntry.PRODUCT_DESCRIPTION_PROP_NAME, "description" ) &&
+                    notAttribute( prop, product, JposEntry.PRODUCT_URL_PROP_NAME, "url" )
+            )
+                addPropElement( doc, jposEntryElement, prop );
+        }
+    }
+
+    private List<JposEntry.Prop> getSortedList( Iterator props )
+    {
+        ArrayList<JposEntry.Prop> sortedProps = new ArrayList<>();
+        while( props.hasNext() )
+        {
+            JposEntry.Prop entry = (JposEntry.Prop) props.next();
+            int lowBound = 0;
+            int highBound = sortedProps.size() - 1;
+
+            while( lowBound <= highBound )
+            {
+                int middle = (lowBound + highBound) / 2;
+                int compareresult = entry.getName().compareToIgnoreCase( sortedProps.get( middle ).getName() );
+                if( compareresult == 0 )
+                    lowBound = highBound = middle;
+                else if ( compareresult > 0 )
+                    lowBound = middle + 1;
+                else
+                    highBound = middle - 1;
+            }
+            sortedProps.add( lowBound, entry );
+        }
+        return sortedProps;
+    }
+
+    private boolean notAttribute( JposEntry.Prop prop, Element elem, String propName, String attrName )
+    {
+        if( prop.getName().equals( propName ) )
+        {
+            String value = prop.getValueAsString();
+
+            if( value.length() > 0 ||
+                    ( !JposEntry.PRODUCT_URL_PROP_NAME.equals(propName) &&
+                            !JposEntry.VENDOR_URL_PROP_NAME.equals(propName)
+                    )
+            )
+                elem.setAttribute( attrName, prop.getValueAsString() );
+            return false;
+        }
+        return true;
+    }
+
+    private static void addPropElement( Document doc, Element jposEntryElement, JposEntry.Prop prop )
+    {
+        Element more = doc.createElement( "prop" );
+        jposEntryElement.appendChild( more );
+        more.setAttribute( "name", prop.getName() );
+        more.setAttribute( "value", prop.getValueAsString() );
+        if( !( prop.getValue() instanceof String ) )
+            more.setAttribute( "type", prop.getValue().getClass().getSimpleName() );
+    }
+
+    private void insertDateSavedComment( Document document )
+    {
+        String dateString = DateFormat.getInstance().format( new Date( System.currentTimeMillis() ) );
+        String commentString = "Saved by JavaPOS jpos.config/loader (JCL) version " + Version.getVersionString()
+                + " on " + dateString;
+        Comment comment = document.createComment( commentString );
+        document.getDocumentElement().insertBefore( comment, document.getDocumentElement().getFirstChild() );
+    }
+
+    private Tracer tracer = TracerFactory.getInstance().createTracer( "JavaxRegPopulator" );
+    private static final String JAVAX_REG_POPULATOR_NAME_STRING = "JCL XML Entries Populator";
+
+    private List jposEntryList = new LinkedList();
+
+    private class JavaxSaxHandler
+            extends DefaultHandler
+    {
+        private JposEntry CurrentEntry = null;
+        private SAXException TheException = null;
+
+        @Override
+        public void startElement( String uri, String lname, String qname, Attributes attrs )
+        {
+            tracer.print( "StartElement: "+ qname );
+            if( TheException != null )
+            {
+                tracer.println( ": Parse error: " + TheException.getMessage() );
+                lastLoadException = TheException;
+                TheException = null;
+                return;
+            }
+            if( qname.equals( "JposEntries" ) )
+                jposEntryList.clear();
+            else if( qname.equals( "JposEntry" ) )
+                CurrentEntry = new SimpleEntry(attrs.getValue("logicalName"), JavaxRegPopulator.this);
+            else if( CurrentEntry != null )
+            {
+                String temp;
+
+                if( qname.equals( "creation" ) )
+                {
+                    CurrentEntry.addProperty( JposEntry.SI_FACTORY_CLASS_PROP_NAME, attrs.getValue( "factoryClass" ) );
+                    CurrentEntry.addProperty( JposEntry.SERVICE_CLASS_PROP_NAME, attrs.getValue( "serviceClass" ) );
+                }
+                else if( qname.equals( "vendor" ) )
+                {
+                    CurrentEntry.addProperty( JposEntry.VENDOR_NAME_PROP_NAME, attrs.getValue( "name" ) );
+                    addOptionalProperty( JposEntry.VENDOR_URL_PROP_NAME, attrs.getValue( "url" ) );
+                }
+                else if( qname.equals( "jpos" ) )
+                {
+                    CurrentEntry.addProperty( JposEntry.JPOS_VERSION_PROP_NAME, attrs.getValue( "version" ) );
+                    CurrentEntry.addProperty( JposEntry.DEVICE_CATEGORY_PROP_NAME, attrs.getValue( "category" ) );
+                }
+                else if( qname.equals( "product" ) )
+                {
+                    CurrentEntry.addProperty( JposEntry.PRODUCT_NAME_PROP_NAME, attrs.getValue( "name" ) );
+                    CurrentEntry.addProperty( JposEntry.PRODUCT_DESCRIPTION_PROP_NAME, attrs.getValue( "description" ) );
+                    addOptionalProperty( JposEntry.PRODUCT_URL_PROP_NAME, attrs.getValue( "url" ) );
+                }
+                else if( qname.equals( "prop" ) )
+                {
+                    temp = attrs.getValue( "type" );
+                    try
+                    {
+                        Class type = temp == null ? String.class : Class.forName( "java.lang." + temp );
+                        Object obj = null;
+                        obj = JposEntryUtility.parsePropValue( attrs.getValue( "value" ), type );
+                        CurrentEntry.addProperty( attrs.getValue( "name" ), obj );
+                    }
+                    catch( Exception e )
+                    {
+                        CurrentEntry = null;
+                        String msg = "Invalid prop: name=" + attrs.getValue( "name" )
+                                + ":value=" + attrs.getValue( "value" );
+                        tracer.println( ": " + msg );
+                        lastLoadException =  new SAXException( msg, e );
+                    };
+                }
+            }
+            tracer.println( "" );
+        }
+
+        private void addOptionalProperty( String name, String value )
+        {
+            CurrentEntry.addProperty( name, value == null ? "" : value );
+        }
+
+        @Override
+        public void endElement( String uri, String lname, String qname )
+        {
+            if( TheException == null )
+                tracer.println( "EndElement: " + qname );
+            else
+            {
+                tracer.println( "EndElement: " + TheException.getMessage() );
+                TheException = null;
+            }
+            if( qname.equals( "JposEntry" ) )
+            {
+                if( CurrentEntry != null )
+                    jposEntryList.add( CurrentEntry );
+                CurrentEntry = null;
+                TheException = null;
+            }
+        }
+
+        @Override
+        public void error( SAXParseException e )
+        {
+            CurrentEntry = null;
+            TheException = e;
+        }
+
+        @Override
+        public void fatalError( SAXParseException e )
+        {
+            CurrentEntry = null;
+            TheException = e;
+        }
+    }
+}

--- a/src/main/java/jpos/config/simple/xml/JavaxRegPopulator.java
+++ b/src/main/java/jpos/config/simple/xml/JavaxRegPopulator.java
@@ -27,17 +27,19 @@ import jpos.util.tracing.Tracer;
 import jpos.util.tracing.TracerFactory;
 import org.w3c.dom.*;
 import org.xml.sax.*;
-import org.xml.sax.helpers.DefaultHandler;
+import org.xml.sax.ext.DefaultHandler2;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.*;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
 import java.io.*;
 import java.net.URL;
 import java.text.DateFormat;
@@ -45,237 +47,197 @@ import java.util.*;
 
 /**
  * Simple implementation of the JposRegPopulator that loads and saves
- * the entries in XML using Javax api.
+ * the entries in XML using Javax API.
  * NOTE: this class must define a public no-argument constructor so that it may be
  * created via reflection when it is defined in the jpos.properties as
  * the jpos.config.regPopulatorClass
  * @see jpos.util.JposProperties#JPOS_REG_POPULATOR_CLASS_PROP_NAME
- * @since 1.16
+ * @since 4.0
  * @author M. Conrad (martin.conrad@freenet.de)
  */
 public class JavaxRegPopulator
         extends AbstractRegPopulator
-        implements XmlRegPopulator
-{
+        implements XmlRegPopulator {
     /**
      * Default ctor
      */
-    public JavaxRegPopulator()
-    { super( JavaxRegPopulator.class.getName() ); }
+    public JavaxRegPopulator() {
+        super(JavaxRegPopulator.class.getName());
+    }
 
     /**
      * 1-arg constructor that takes the unique ID
      *
      * @param s the unique ID string
-     * @since 1.3 (Washington DC 2001)
+     * @since 1.3
      */
-    public JavaxRegPopulator( String s )
-    { super(s); }
+    public JavaxRegPopulator(String s) {
+        super(s);
+    }
 
     //-------------------------------------------------------------------------
     // Public methods
     //
 
     @Override
-    public String getClassName() { return JavaxRegPopulator.class.getName(); }
+    public String getClassName() {
+        return JavaxRegPopulator.class.getName();
+    }
 
     @Override
-    public URL getEntriesURL()
-    {
+    public URL getEntriesURL() {
         URL url = null;
 
-        if( getPopulatorFileURL() != null &&
-                !getPopulatorFileURL().equals( "" ) )
-            try
-            { url =  new URL( getPopulatorFileURL() ); }
-            catch( Exception e )
-            {
-                tracer.println( "getEntriesURL: Exception.message=" +
-                        e.getMessage() );
+        if (getPopulatorFileURL() != null &&
+                !getPopulatorFileURL().equals(""))
+            try {
+                url = new URL(getPopulatorFileURL());
+            } catch (Exception e) {
+                tracer.println("getEntriesURL: Exception.message=" +
+                        e.getMessage());
             }
         else
-            url = createURLFromFile( new File( getPopulatorFileName() ) );
+            url = createURLFromFile(new File(getPopulatorFileName()));
 
-        //<temp>
-        tracer.println( "getPopulatorFileURL()=" + getPopulatorFileURL() );
-        tracer.println( "getPopulatorFileName()=" + getPopulatorFileName() );
-        //</temp>
+        tracer.println("getPopulatorFileURL()=" + getPopulatorFileURL());
+        tracer.println("getPopulatorFileName()=" + getPopulatorFileName());
 
         return url;
     }
 
 
     @Override
-    public void save( Enumeration entries )
-            throws Exception
-    {
-        if( isPopulatorFileDefined() )
-            save(entries,  getPopulatorFileOS());
+    public void save(Enumeration entries)
+            throws Exception {
+        if (isPopulatorFileDefined())
+            save(entries, getPopulatorFileOS());
         else
-            try( FileOutputStream os = new FileOutputStream( "jpos.xml" ) )
-            { save( entries, os ); }
-            catch (Exception e)
-            { throw e; }
+            try (FileOutputStream os = new FileOutputStream(DEFAULT_XML_FILE_NAME)) {
+                save(entries, os);
+            }
     }
 
     @Override
-    public void save( Enumeration entries, String fileName )
-            throws Exception
-    {
-        try( FileOutputStream os = new FileOutputStream( fileName ) )
-        { save(entries, os); }
-        catch ( Exception e )
-        { throw e; }
-    }
-
-    @Override
-    public void load()
-    {
-        try( InputStream is = isPopulatorFileDefined() ? new FileInputStream( DEFAULT_XML_FILE_NAME ) : getPopulatorFileIS() )
-        {
-            load( is );
+    public void save(Enumeration entries, String fileName)
+            throws Exception {
+        try (FileOutputStream os = new FileOutputStream(fileName)) {
+            save(entries, os);
         }
-        catch( Exception e )
-        {
-            tracer.println( "Error while loading populator file Exception.message: " +
-                    e.getMessage() );
+    }
+
+    @Override
+    public void load() {
+        try (InputStream is = isPopulatorFileDefined() ? new FileInputStream(DEFAULT_XML_FILE_NAME) : getPopulatorFileIS()) {
+            load(is);
+        } catch (Exception e) {
+            tracer.println("Error while loading populator file Exception.message: " +
+                    e.getMessage());
             lastLoadException = e;
         }
     }
 
     @Override
-    public void load( String fileName )
-    {
-        try( InputStream is = new File( fileName ).exists() ? new FileInputStream( fileName ) : findFileInClasspath( fileName ) )
-        {
-            load( is );
-        }
-        catch( Exception e )
-        {
-            tracer.println( "Error while loading populator file Exception.message: " +
-                    e.getMessage() );
+    public void load(String fileName) {
+        try (InputStream is = new File(fileName).exists() ? new FileInputStream(fileName) : findFileInClasspath(fileName)) {
+            load(is);
+        } catch (Exception e) {
+            tracer.println("Error while loading populator file Exception.message: " +
+                    e.getMessage());
             lastLoadException = e;
         }
     }
 
     @Override
-    public String getName() { return JAVAX_REG_POPULATOR_NAME_STRING; }
+    public String getName() {
+        return JAVAX_REG_POPULATOR_NAME_STRING;
+    }
 
     //--------------------------------------------------------------------------
-    // Protected methods
+    // Private methods
     //
 
+    private void save(Enumeration<JposEntry> entries, OutputStream outputStream)
+            throws ParserConfigurationException, TransformerFactoryConfigurationError, TransformerException {
+        Document document = createEmptyDocument();
 
-    /** @return the Tracer object */
-    protected Tracer getTracer() { return tracer; }
+        insertJposEntriesInDoc(entries, document);
+        insertDateSavedComment(document);
 
-    /**
-     * @return the default XML file name that this populator will save
-     * entries to
-     */
-    protected String getDefaultXmlFileName() { return xmlFileName; }
+        DOMSource source = new DOMSource(document);
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "file,jar:file");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "file,jar:file");
+        Transformer transformer = factory.newTransformer();
 
-    private void save( Enumeration entries, OutputStream outputStream )
-            throws Exception
-    {
-        Document document = CreateEmptyDocument();
-
-        insertJposEntriesInDoc( entries, document );
-        insertDateSavedComment( document );
-
-        DOMSource source = new DOMSource( document );
-        Transformer transformer = TransformerFactory.newInstance().newTransformer();
-
-        transformer.setOutputProperty( OutputKeys.INDENT, "yes" );
-        transformer.setOutputProperty( "{http://xml.apache.org/xslt}indent-amount", "4" );
-        transformer.setOutputProperty( OutputKeys.DOCTYPE_PUBLIC, document.getDoctype().getPublicId() );
-        transformer.setOutputProperty( OutputKeys.DOCTYPE_SYSTEM, document.getDoctype().getSystemId() );
-        transformer.transform( source, new StreamResult( outputStream ) );
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+        transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, document.getDoctype().getPublicId());
+        transformer.setOutputProperty(OutputKeys.DOCTYPE_SYSTEM, document.getDoctype().getSystemId());
+        transformer.transform(source, new StreamResult(outputStream));
     }
 
-    private Document CreateEmptyDocument()
-            throws ParserConfigurationException
-    {
+    private Document createEmptyDocument()
+            throws ParserConfigurationException {
         DOMImplementation domImpl = DocumentBuilderFactory.newInstance().newDocumentBuilder().getDOMImplementation();
-        DocumentType docType = domImpl.createDocumentType( "JposEntries", DTD_DOC_TYPE_VALUE, DTD_FILE_NAME );
+        DocumentType docType = domImpl.createDocumentType("JposEntries", DTD_DOC_TYPE_VALUE, DTD_FILE_NAME);
 
         return domImpl.createDocument(null, "JposEntries", docType);
     }
 
 
-    private void insertJposEntriesInDoc( Enumeration entries, Document doc )
-    {
-        while( entries.hasMoreElements() )
-        {
-            JposEntry jposEntry = (JposEntry) entries.nextElement();
+    private void insertJposEntriesInDoc(Enumeration<JposEntry> entries, Document doc) {
+        while (entries.hasMoreElements()) {
+            JposEntry jposEntry = entries.nextElement();
 
-            if( JposEntryUtility.isValidJposEntry( jposEntry ) )
-            {
-                Element jposEntryElement = doc.createElement( "JposEntry" );
+            if (JposEntryUtility.isValidJposEntry(jposEntry)) {
+                Element jposEntryElement = doc.createElement("JposEntry");
 
-                jposEntryElement.setAttribute( "logicalName", jposEntry.getLogicalName() );
-                insertJposPropertiesInElement( doc, jposEntry, jposEntryElement );
-                doc.getDocumentElement().appendChild( jposEntryElement );
+                jposEntryElement.setAttribute("logicalName", jposEntry.getLogicalName());
+                insertJposPropertiesInElement(doc, jposEntry, jposEntryElement);
+                doc.getDocumentElement().appendChild(jposEntryElement);
             }
         }
     }
 
-    private void insertJposPropertiesInElement( Document doc, JposEntry jposEntry, Element jposEntryElement )
-    {
-        Element creation = doc.createElement( "creation" );
-        Element jpos = doc.createElement( "jpos" );
-        Element product = doc.createElement( "product" );
-        Element vendor = doc.createElement( "vendor" );
+    private void insertJposPropertiesInElement(Document doc, JposEntry jposEntry, Element jposEntryElement) {
+        Element creation = doc.createElement("creation");
+        Element jpos = doc.createElement("jpos");
+        Element product = doc.createElement("product");
+        Element vendor = doc.createElement("vendor");
 
-        for( Element tag : new Element[] { creation, vendor, jpos, product } )
+        for (Element tag : new Element[]{creation, vendor, jpos, product})
             jposEntryElement.appendChild(tag);
 
-        List<JposEntry.Prop> sortedProps = getSortedList( jposEntry.getProps() );
-        for( JposEntry.Prop prop : sortedProps )
-        {
-            if( notAttribute( prop, creation, JposEntry.SERVICE_CLASS_PROP_NAME, "serviceClass" ) &&
-                    notAttribute( prop, creation, JposEntry.SI_FACTORY_CLASS_PROP_NAME, "factoryClass" ) &&
-                    notAttribute( prop, vendor, JposEntry.VENDOR_NAME_PROP_NAME, "name" ) &&
-                    notAttribute( prop, vendor, JposEntry.VENDOR_URL_PROP_NAME, "url" ) &&
-                    notAttribute( prop, jpos, JposEntry.JPOS_VERSION_PROP_NAME, "version" ) &&
-                    notAttribute( prop, jpos, JposEntry.DEVICE_CATEGORY_PROP_NAME, "category" ) &&
-                    notAttribute( prop, product, JposEntry.PRODUCT_NAME_PROP_NAME, "name" ) &&
-                    notAttribute( prop, product, JposEntry.PRODUCT_DESCRIPTION_PROP_NAME, "description" ) &&
-                    notAttribute( prop, product, JposEntry.PRODUCT_URL_PROP_NAME, "url" )
+        List<JposEntry.Prop> sortedProps = getSortedList(jposEntry.getProps());
+        for (JposEntry.Prop prop : sortedProps) {
+            if (notAttribute(prop, creation, JposEntry.SERVICE_CLASS_PROP_NAME, "serviceClass") &&
+                    notAttribute(prop, creation, JposEntry.SI_FACTORY_CLASS_PROP_NAME, "factoryClass") &&
+                    notAttribute(prop, vendor, JposEntry.VENDOR_NAME_PROP_NAME, "name") &&
+                    notAttribute(prop, vendor, JposEntry.VENDOR_URL_PROP_NAME, "url") &&
+                    notAttribute(prop, jpos, JposEntry.JPOS_VERSION_PROP_NAME, "version") &&
+                    notAttribute(prop, jpos, JposEntry.DEVICE_CATEGORY_PROP_NAME, "category") &&
+                    notAttribute(prop, product, JposEntry.PRODUCT_NAME_PROP_NAME, "name") &&
+                    notAttribute(prop, product, JposEntry.PRODUCT_DESCRIPTION_PROP_NAME, "description") &&
+                    notAttribute(prop, product, JposEntry.PRODUCT_URL_PROP_NAME, "url")
             )
-                addPropElement( doc, jposEntryElement, prop );
+                addPropElement(doc, jposEntryElement, prop);
         }
     }
 
-    private List<JposEntry.Prop> getSortedList( Iterator props )
-    {
+    private List<JposEntry.Prop> getSortedList(Iterator<JposEntry.Prop> props) {
         ArrayList<JposEntry.Prop> sortedProps = new ArrayList<>();
-        while( props.hasNext() )
-        {
-            JposEntry.Prop entry = (JposEntry.Prop) props.next();
-            int lowBound = 0;
-            int highBound = sortedProps.size() - 1;
-
-            while( lowBound <= highBound )
-            {
-                int middle = (lowBound + highBound) / 2;
-                int compareresult = entry.getName().compareToIgnoreCase( sortedProps.get( middle ).getName() );
-                if( compareresult == 0 )
-                    lowBound = highBound = middle;
-                else if ( compareresult > 0 )
-                    lowBound = middle + 1;
-                else
-                    highBound = middle - 1;
+        props.forEachRemaining(sortedProps::add);
+        Collections.sort(sortedProps, new Comparator<JposEntry.Prop>() {
+            @Override
+            public int compare(JposEntry.Prop o1, JposEntry.Prop o2) {
+                return o1.getName().compareToIgnoreCase(o2.getName());
             }
-            sortedProps.add( lowBound, entry );
-        }
+        });
         return sortedProps;
     }
 
-    private boolean notAttribute( JposEntry.Prop prop, Element elem, String propName, String attrName )
-    {
-        if( prop.getName().equals( propName ) )
-        {
+    private boolean notAttribute(JposEntry.Prop prop, Element elem, String propName, String attrName) {
+        if (prop.getName().equals(propName)) {
             String value = prop.getValueAsString();
             /* Change /* to //* to generate implicit attribute values only if value is not empty.
             if( value.length() > 0 ||
@@ -284,63 +246,61 @@ public class JavaxRegPopulator
                     )
             )
                 //*/
-            elem.setAttribute( attrName, prop.getValueAsString() );
+            elem.setAttribute(attrName, prop.getValueAsString());
             return false;
         }
         return true;
     }
 
-    private static void addPropElement( Document doc, Element jposEntryElement, JposEntry.Prop prop )
-    {
-        Element more = doc.createElement( "prop" );
-        jposEntryElement.appendChild( more );
-        more.setAttribute( "name", prop.getName() );
-        more.setAttribute( "value", prop.getValueAsString() );
-        if( !( prop.getValue() instanceof String ) )
-            more.setAttribute( "type", prop.getValue().getClass().getSimpleName() );
+    private static void addPropElement(Document doc, Element jposEntryElement, JposEntry.Prop prop) {
+        Element propElement = doc.createElement("prop");
+        jposEntryElement.appendChild(propElement);
+        propElement.setAttribute("name", prop.getName());
+        propElement.setAttribute("value", prop.getValueAsString());
+        if (!(prop.getValue() instanceof String))
+            propElement.setAttribute("type", prop.getValue().getClass().getSimpleName());
     }
 
-    private void insertDateSavedComment( Document document )
-    {
-        String dateString = DateFormat.getInstance().format( new Date( System.currentTimeMillis() ) );
-        String commentString = "Saved by JavaPOS jpos.config/loader (JCL) version " + Version.getVersionString()
+    private void insertDateSavedComment(Document document) {
+        String dateString = DateFormat.getInstance().format(new Date(System.currentTimeMillis()));
+        String commentString = "Saved by javapos-config-loader (JCL) version " + Version.getVersionString()
                 + " on " + dateString;
-        Comment comment = document.createComment( commentString );
-        document.getDocumentElement().insertBefore( comment, document.getDocumentElement().getFirstChild() );
+        Comment comment = document.createComment(commentString);
+        document.getDocumentElement().insertBefore(comment, document.getDocumentElement().getFirstChild());
     }
 
-    private void load( InputStream inputStream )
-    {
+    private void load(InputStream inputStream) {
         SAXParserFactory parserFactory = SAXParserFactory.newInstance();
         JavaxSaxHandler saxHandler = new JavaxSaxHandler();
-
-        parserFactory.setNamespaceAware( true );
-        parserFactory.setValidating( true );
+        try {
+            InputStream is = findFileInClasspath(XSD_FILE_NAME);
+            StreamSource ss = new StreamSource(is == null ? new FileInputStream(XSD_FILE_NAME) : is);
+            Schema schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema(ss);
+            parserFactory.setSchema(schema);
+        } catch (Exception e) {
+            parserFactory.setValidating(true);
+        }
+        parserFactory.setNamespaceAware(true);
         jposEntryList.clear();
-        try
-        {
-            parserFactory.newSAXParser().parse( inputStream, saxHandler );
-        }
-        catch (SAXException e)
-        {
-            tracer.println( "SAX Parser error, msg=" + e.getMessage() );
+        try {
+            SAXParser parser = parserFactory.newSAXParser();
+            parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "file");
+            parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "file,jar:file");
+            parser.parse(inputStream, saxHandler);
+        } catch (SAXException e) {
+            tracer.println("SAX Parser error, msg=" + e.getMessage());
+            lastLoadException = e;
+        } catch (IOException e) {
+            tracer.println("XML file access error, msg=" + e.getMessage());
+            lastLoadException = e;
+        } catch (ParserConfigurationException e) {
+            tracer.println("SAX Parser configuration error, msg=" + e.getMessage());
             lastLoadException = e;
         }
-        catch ( IOException e )
-        {
-            tracer.println( "XML file access error, msg=" + e.getMessage() );
-            lastLoadException = e;
-        }
-        catch ( ParserConfigurationException e )
-        {
-            tracer.println( "SAX Parser configuration error, msg=" + e.getMessage() );
-            lastLoadException = e;
-        }
-        Iterator entries = jposEntryList.iterator();
-        while( entries.hasNext() )
-        {
-            JposEntry jposEntry = (JposEntry) entries.next();
-            getJposEntries().put( jposEntry.getLogicalName(), jposEntry );
+        Iterator<JposEntry> entries = jposEntryList.iterator();
+        while (entries.hasNext()) {
+            JposEntry jposEntry = entries.next();
+            getJposEntries().put(jposEntry.getLogicalName(), jposEntry);
         }
     }
 
@@ -349,98 +309,79 @@ public class JavaxRegPopulator
     //
 
     private class JavaxSaxHandler
-            extends DefaultHandler
-    {
-        private JposEntry CurrentEntry = null;
-        private SAXException TheException = null;
+            extends DefaultHandler2 {
+        private JposEntry currentEntry = null;
+        private SAXException theException = null;
 
         //----------------------------------------------------------------
         // ContentHandler
 
         @Override
-        public void startElement( String uri, String lname, String qname, Attributes attrs )
-        {
-            tracer.print( "StartElement: "+ qname );
-            if( TheException != null )
-            {
-                tracer.println( ": Parse error: " + TheException.getMessage() );
-                lastLoadException = TheException;
-                TheException = null;
+        public void startElement(String uri, String lname, String qname, Attributes attrs) {
+            tracer.print("StartElement: " + qname);
+            if (theException != null) {
+                tracer.println(": Parse error: " + theException.getMessage());
+                lastLoadException = theException;
+                theException = null;
                 return;
             }
-            if( qname.equals( "JposEntries" ) )
+            if (qname.equals("JposEntries"))
                 jposEntryList.clear();
-            else if( qname.equals( "JposEntry" ) )
-                CurrentEntry = new SimpleEntry(attrs.getValue("logicalName"), JavaxRegPopulator.this);
-            else if( CurrentEntry != null )
-            {
+            else if (qname.equals("JposEntry"))
+                currentEntry = new SimpleEntry(attrs.getValue("logicalName"), JavaxRegPopulator.this);
+            else if (currentEntry != null) {
                 String temp;
 
-                if( qname.equals( "creation" ) )
-                {
-                    CurrentEntry.addProperty( JposEntry.SI_FACTORY_CLASS_PROP_NAME, attrs.getValue( "factoryClass" ) );
-                    CurrentEntry.addProperty( JposEntry.SERVICE_CLASS_PROP_NAME, attrs.getValue( "serviceClass" ) );
-                }
-                else if( qname.equals( "vendor" ) )
-                {
-                    CurrentEntry.addProperty( JposEntry.VENDOR_NAME_PROP_NAME, attrs.getValue( "name" ) );
-                    addOptionalProperty( JposEntry.VENDOR_URL_PROP_NAME, attrs.getValue( "url" ) );
-                }
-                else if( qname.equals( "jpos" ) )
-                {
-                    CurrentEntry.addProperty( JposEntry.JPOS_VERSION_PROP_NAME, attrs.getValue( "version" ) );
-                    CurrentEntry.addProperty( JposEntry.DEVICE_CATEGORY_PROP_NAME, attrs.getValue( "category" ) );
-                }
-                else if( qname.equals( "product" ) )
-                {
-                    CurrentEntry.addProperty( JposEntry.PRODUCT_NAME_PROP_NAME, attrs.getValue( "name" ) );
-                    CurrentEntry.addProperty( JposEntry.PRODUCT_DESCRIPTION_PROP_NAME, attrs.getValue( "description" ) );
-                    addOptionalProperty( JposEntry.PRODUCT_URL_PROP_NAME, attrs.getValue( "url" ) );
-                }
-                else if( qname.equals( "prop" ) )
-                {
-                    temp = attrs.getValue( "type" );
-                    try
-                    {
-                        Class type = temp == null ? String.class : Class.forName( "java.lang." + temp );
+                if (qname.equals("creation")) {
+                    currentEntry.addProperty(JposEntry.SI_FACTORY_CLASS_PROP_NAME, attrs.getValue("factoryClass"));
+                    currentEntry.addProperty(JposEntry.SERVICE_CLASS_PROP_NAME, attrs.getValue("serviceClass"));
+                } else if (qname.equals("vendor")) {
+                    currentEntry.addProperty(JposEntry.VENDOR_NAME_PROP_NAME, attrs.getValue("name"));
+                    addOptionalProperty(JposEntry.VENDOR_URL_PROP_NAME, attrs.getValue("url"));
+                } else if (qname.equals("jpos")) {
+                    currentEntry.addProperty(JposEntry.JPOS_VERSION_PROP_NAME, attrs.getValue("version"));
+                    currentEntry.addProperty(JposEntry.DEVICE_CATEGORY_PROP_NAME, attrs.getValue("category"));
+                } else if (qname.equals("product")) {
+                    currentEntry.addProperty(JposEntry.PRODUCT_NAME_PROP_NAME, attrs.getValue("name"));
+                    currentEntry.addProperty(JposEntry.PRODUCT_DESCRIPTION_PROP_NAME, attrs.getValue("description"));
+                    addOptionalProperty(JposEntry.PRODUCT_URL_PROP_NAME, attrs.getValue("url"));
+                } else if (qname.equals("prop")) {
+                    temp = attrs.getValue("type");
+                    try {
+                        Class<?> type = temp == null ? String.class : Class.forName("java.lang." + temp);
                         Object obj = null;
-                        obj = JposEntryUtility.parsePropValue( attrs.getValue( "value" ), type );
-                        CurrentEntry.addProperty( attrs.getValue( "name" ), obj );
+                        obj = JposEntryUtility.parsePropValue(attrs.getValue("value"), type);
+                        currentEntry.addProperty(attrs.getValue("name"), obj);
+                    } catch (Exception e) {
+                        currentEntry = null;
+                        String msg = "Invalid prop: name=" + attrs.getValue("name")
+                                + ":value=" + attrs.getValue("value");
+                        tracer.println(": " + msg);
+                        lastLoadException = new SAXException(msg, e);
                     }
-                    catch( Exception e )
-                    {
-                        CurrentEntry = null;
-                        String msg = "Invalid prop: name=" + attrs.getValue( "name" )
-                                + ":value=" + attrs.getValue( "value" );
-                        tracer.println( ": " + msg );
-                        lastLoadException =  new SAXException( msg, e );
-                    };
+                    ;
                 }
             }
-            tracer.println( "" );
+            tracer.println("");
         }
 
-        private void addOptionalProperty( String name, String value )
-        {
-            CurrentEntry.addProperty( name, value == null ? "" : value );
+        private void addOptionalProperty(String name, String value) {
+            currentEntry.addProperty(name, value == null ? "" : value);
         }
 
         @Override
-        public void endElement( String uri, String lname, String qname )
-        {
-            if( TheException == null )
-                tracer.println( "EndElement: " + qname );
-            else
-            {
-                tracer.println( "EndElement: " + TheException.getMessage() );
-                TheException = null;
+        public void endElement(String uri, String lname, String qname) {
+            if (theException == null)
+                tracer.println("EndElement: " + qname);
+            else {
+                tracer.println("EndElement: " + theException.getMessage());
+                theException = null;
             }
-            if( qname.equals( "JposEntry" ) )
-            {
-                if( CurrentEntry != null )
-                    jposEntryList.add( CurrentEntry );
-                CurrentEntry = null;
-                TheException = null;
+            if (qname.equals("JposEntry")) {
+                if (currentEntry != null)
+                    jposEntryList.add(currentEntry);
+                currentEntry = null;
+                theException = null;
             }
         }
 
@@ -448,41 +389,37 @@ public class JavaxRegPopulator
         // ErrorHandler
 
         @Override
-        public void error( SAXParseException e )
-        {
-            CurrentEntry = null;
-            TheException = e;
+        public void error(SAXParseException e) {
+            currentEntry = null;
+            theException = e;
         }
 
         @Override
-        public void fatalError( SAXParseException e )
-        {
-            CurrentEntry = null;
-            TheException = e;
+        public void fatalError(SAXParseException e) {
+            currentEntry = null;
+            theException = e;
         }
 
         //----------------------------------------------------------------
         // EntityResolver
 
         @Override
-        public InputSource resolveEntity(String publicId, String systemId )
-        {
-            tracer.println( "JposEntityResolver:resolveEntity:publicId=" +
-                    publicId );
+        public InputSource resolveEntity(String name, String publicId, String uri, String systemId) {
+            tracer.println("JposEntityResolver:resolveEntity:publicId=" +
+                    publicId);
 
-            tracer.println( "JposEntityResolver:resolveEntity:systemId=" +
-                    systemId );
+            tracer.println("JposEntityResolver:resolveEntity:systemId=" +
+                    systemId);
 
-            if( publicId.equals( DTD_DOC_TYPE_VALUE ) )
-            {
+            if (publicId.equals(DTD_DOC_TYPE_VALUE)) {
                 InputStream is =
-                        getClass().getResourceAsStream( DTD_FILE_NAME );
+                        getClass().getResourceAsStream(DTD_FILE_NAME);
 
-                if ( is == null )
-                    is = findFileInClasspath( DTD_FILE_NAME );
+                if (is == null)
+                    is = findFileInClasspath(DTD_FILE_NAME);
 
-                if( is != null )
-                    return new InputSource( new InputStreamReader( is ) );
+                if (is != null)
+                    return new InputSource(new InputStreamReader(is));
             }
 
             return null;
@@ -493,12 +430,10 @@ public class JavaxRegPopulator
     // Instance variables
     //
 
-    protected String xmlFileName = DEFAULT_XML_FILE_NAME;
-
-    private List jposEntryList = new LinkedList();
+    private List<JposEntry> jposEntryList = new LinkedList<>();
 
     private Tracer tracer = TracerFactory.getInstance().
-            createTracer( this.getClass().getSimpleName() );
+            createTracer(this.getClass().getSimpleName());
 
     //--------------------------------------------------------------------------
     // Constants
@@ -506,6 +441,8 @@ public class JavaxRegPopulator
 
     public static final String DTD_FILE_PATH = "jpos/res";
     public static final String DTD_FILE_NAME = DTD_FILE_PATH + "/jcl.dtd";
+
+    public static final String XSD_FILE_NAME = DTD_FILE_PATH + "/jcl.xsd";
 
     public static final String DTD_DOC_TYPE_VALUE = "-//JavaPOS//DTD//EN";
 

--- a/src/main/java/jpos/config/simple/xml/SimpleXmlRegPopulator.java
+++ b/src/main/java/jpos/config/simple/xml/SimpleXmlRegPopulator.java
@@ -129,5 +129,5 @@ public class SimpleXmlRegPopulator extends AbstractRegPopulator
     // Instance variables
     //
 
-    private XmlRegPopulator regPopulator = new XercesRegPopulator();
+    private XmlRegPopulator regPopulator = new JavaxRegPopulator();
 }

--- a/src/main/java/jpos/config/simple/xml/Xerces2RegPopulator.java
+++ b/src/main/java/jpos/config/simple/xml/Xerces2RegPopulator.java
@@ -367,7 +367,7 @@ public class Xerces2RegPopulator extends AbstractXercesRegPopulator
 									  factoryClass );
 									  
 			currentEntry.addProperty( JposEntry.VENDOR_URL_PROP_NAME, 
-									  serviceClass );			
+									  serviceClass == null ? "" : serviceClass );
 		}	    								
 		
 	    protected void addJposProp( JposEntry entry, 
@@ -403,7 +403,7 @@ public class Xerces2RegPopulator extends AbstractXercesRegPopulator
 									  name );						
 			
 			currentEntry.addProperty( JposEntry.PRODUCT_URL_PROP_NAME,
-						  			  url );						
+						  			  url == null ? "" : url);
 		}
 			    								
 	    protected void addProp( JposEntry entry, 
@@ -421,7 +421,7 @@ public class Xerces2RegPopulator extends AbstractXercesRegPopulator
 			{
 			
 				Class typeClass = JposEntryUtility.
-				propTypeFromString( attributes.getValue( "type" ) );
+				propTypeFromString( typeString );
 				
 				Object value = JposEntryUtility.parsePropValue( valueString, typeClass );
 				

--- a/src/main/java/jpos/config/simple/xml/XmlRegPopulator.java
+++ b/src/main/java/jpos/config/simple/xml/XmlRegPopulator.java
@@ -37,4 +37,123 @@ public interface XmlRegPopulator extends JposRegPopulator
      * @since 1.2 (NY 2K meeting)
      */
     public static final String DEFAULT_XML_FILE_NAME = "jpos.xml";
+
+    /**
+     * Default path for dtd and / or xsd file
+     * @since 4.0
+     */
+    public static final String DTD_FILE_PATH = "jpos/res";
+
+    /**
+     * Default name for dtd file
+     * @since 4.0
+     */
+    public static final String DTD_FILE_NAME = DTD_FILE_PATH + "/jcl.dtd";
+
+    /**
+     * Default name for xsd file
+     * @since 4.0
+     */
+    public static final String XSD_FILE_NAME = DTD_FILE_PATH + "/jcl.xsd";
+
+    /**
+     * Default DTD document type value
+     */
+    public static final String DTD_DOC_TYPE_VALUE = "-//JavaPOS//DTD//EN";
+
+    /**
+     * Define for tag name <i>JposEntries</i>
+     * @since 4.0
+     */
+    public static final String XML_TAG_JPOSENTRIES = "JposEntries";
+
+    /**
+     * Define for tag name <i>JposEntry</i>
+     * @since 4.0
+     */
+    public static final String XML_TAG_JPOSENTRY = "JposEntry";
+
+    /**
+     * Define for tag name <i>creation</i>
+     * @since 4.0
+     */
+    public static final String XML_TAG_CREATION = "creation";
+
+    /**
+     * Define for tag name <i>vendor</i>
+     * @since 4.0
+     */
+    public static final String XML_TAG_VENDOR = "vendor";
+
+    /**
+     * Define for tag name <i>jpos</i>
+     * @since 4.0
+     */
+    public static final String XML_TAG_JPOS = "jpos";
+
+    /**
+     * Define for tag name <i>product</i>
+     * @since 4.0
+     */
+    public static final String XML_TAG_PRODUCT = "product";
+
+    /**
+     * Define for tag name <i>prop</i>
+     * @since 4.0
+     */
+    public static final String XML_TAG_PROP = "prop";
+
+    /**
+     * Define for attribute name <i>serviceClass</i>
+     * @since 4.0
+     */
+    public static final String XML_ATTR_SERVICECLASS = "serviceClass";
+
+    /**
+     * Define for attribute name <i>factoryClass</i>
+     * @since 4.0
+     */
+    public static final String XML_ATTR_FACTORYCLASS= "factoryClass";
+
+    /**
+     * Define for attribute name <i>name</i>
+     * @since 4.0
+     */
+    public static final String XML_ATTR_NAME = "name";
+
+    /**
+     * Define for attribute name <i>url</i>
+     * @since 4.0
+     */
+    public static final String XML_ATTR_URL = "url";
+
+    /**
+     * Define for attribute name <i>name</i>
+     * @since 4.0
+     */
+    public static final String XML_ATTR_VERSION = "version";
+
+    /**
+     * Define for attribute name <i>category</i>
+     * @since 4.0
+     */
+    public static final String XML_ATTR_CATEGORY = "category";
+
+    /**
+     * Define for attribute name <i>description</i>
+     * @since 4.0
+     */
+    public static final String XML_ATTR_DESCRIPTION = "description";
+
+    /**
+     * Define for attribute name <i>value</i>
+     * @since 4.0
+     */
+    public static final String XML_ATTR_VALUE = "value";
+
+    /**
+     * Define for attribute name <i>type</i>
+     * @since 4.0
+     */
+    public static final String XML_ATTR_TYPE = "type";
 }

--- a/src/main/java/jpos/util/JposEntryUtility.java
+++ b/src/main/java/jpos/util/JposEntryUtility.java
@@ -345,28 +345,28 @@ public class JposEntryUtility extends Object
 				propValue = "";
 			else
 			if( propType.equals( Boolean.class ) )
-				propValue = new Boolean( false );
+				propValue = false;
 			else
 			if( propType.equals( Character.class ) )
-				propValue = new Character( 'a' );
+				propValue = 'a';
 			else
 			if( propType.equals( Double.class ) )
-				propValue = new Double( 0 );
+				propValue = (double) 0;
 			else
 			if( propType.equals( Float.class ) )
-				propValue = new Float( 0 );
+				propValue = (float) 0;
 			else
 			if( propType.equals( Byte.class ) )
-				propValue = new Byte( (byte)0 );
+				propValue = (byte) 0;
 			else
 			if( propType.equals( Integer.class ) )
-				propValue = new Integer( 0 );
+				propValue = (int) 0 ;
 			else
 			if( propType.equals( Long.class ) )
-				propValue = new Long( 0 );
+				propValue = (long) 0 ;
 			else
 			if( propType.equals( Short.class ) )
-				propValue = new Short( (short)0 );
+				propValue = (short) 0 ;
 		}
 		catch( Exception e )
 		{ throw new JposConfigException( "Invalid property type" ); }
@@ -400,7 +400,7 @@ public class JposEntryUtility extends Object
 				propValue = Boolean.valueOf( stringValue );
 			else
 			if( propType.equals( Character.class ) )
-				propValue = new Character( stringValue.charAt( 0 ) );
+				propValue = (char) stringValue.charAt( 0 );
 			else
 			if( propType.equals( Double.class ) )
 				propValue = Double.valueOf( stringValue );

--- a/src/main/resources/jpos/res/jcl.dtd
+++ b/src/main/resources/jpos/res/jcl.dtd
@@ -35,11 +35,12 @@
 <!ATTLIST jpos
           version CDATA #REQUIRED
           category ( Belt | BillAcceptor | BillDispenser | Biometrics | BumpBar | CashChanger | CashDrawer | CAT |
-                     CheckScanner | CoinAcceptor | CoinDispenser | ElectronicJournal | ElectronicValueRW |
-                     FiscalPrinter | Gate | HardTotals | ImageScanner | ItemDispenser | Keylock | Lights |
-                     LineDisplay | MICR | MotionSensor | MSR |  PINPad | PointCardRW | POSKeyboard | POSPower |
-                     POSPrinter | RemoteOrderDisplay | RFIDScanner | Scale | Scanner | SignatureCapture |
-                     SmartCardRW | ToneIndicator
+                     CheckScanner | CoinAcceptor | CoinDispenser | DeviceMonitor | ElectronicJournal |
+                     ElectronicValueRW | FiscalPrinter | Gate | GestureControl | GraphicDisplay | HardTotals |
+                     ImageScanner | IndividualRecognition | ItemDispenser | Keylock | Lights | LineDisplay | MICR |
+                     MotionSensor | MSR |  PINPad | PointCardRW | POSKeyboard | POSPower | POSPrinter |
+                     RemoteOrderDisplay | RFIDScanner | Scale | Scanner | SignatureCapture | SmartCardRW |
+                     SoundPlayer | SoundRecorder | SpeechSynthesis | ToneIndicator | VideoCapture | VoiceRecognition
                    ) #REQUIRED>
                      
 <!ATTLIST product 


### PR DESCRIPTION
This pull request consists of three separate commits which can be used (partly) independent from each other.

Commit [Product Maintenance](https://github.com/JavaPOSWorkingGroup/javapos-config-loader/commit/4e3fec226f9e35c6f42ed3dadd0e10b4ea1aa802): This commit reduces deprecation warnings. Deprecated constructors have been replaced by simple assignments. It is independent from the other commits.

Commit [XML Handling Extended By Javax Based Variant](https://github.com/JavaPOSWorkingGroup/javapos-config-loader/commit/1c7230efc61cd476516ed63fe734f8bc9d381c4e): This adds an XML registry populator bases on javax instead of xalan/xerces and allows to remove the dependency from the corresponding external java library. It is independent from the other commits.

Commit [Standard Dependency Reduction](https://github.com/JavaPOSWorkingGroup/javapos-config-loader/commit/d79f2a4c98c120f94b04833aad20b3da23c53fab): This modifies the SimpleXMLRegPopulator class to use the new JavaxRegPopulator class instead of the XercesRegPopulator class and therefore removes the dependency from Xalan/Xerces whenever the default in jpos.properties has not been changed. It is independent from the _Product Maintenance_ commit, but for this commit, the commit _XML Handling Extended By Javax Based Variant_ is mandatory.

Commit [New Device Classes Added](https://github.com/JavaPOSWorkingGroup/javapos-config-loader/commit/6536742fe8a488dcf154d36c3a71be8b590cc4c9): This commit was probably already unnecessary due to the changes made for version 1.16 in the meantime.