### PR TITLE
Fix JAR resource loading

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,6 @@ name: Check PR
 
 on:
   pull_request:
-  workflow_dispatch:
 
 jobs:
   javapos-workflow:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,7 @@ name: Check PR
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   javapos-workflow:

--- a/src/main/java/jpos/config/simple/AbstractRegPopulator.java
+++ b/src/main/java/jpos/config/simple/AbstractRegPopulator.java
@@ -408,10 +408,8 @@ public abstract class AbstractRegPopulator implements JposRegPopulator
     {
         InputStream is = null;
 
-        for( int i = 0; i < jarZipFilesList.size(); ++i )
+        for (String jarZipFileName : jarZipFilesList)
         {
-            String jarZipFileName = jarZipFilesList.get( i );
-
             try
             {
             	ZipFile zipFile = new ZipFile( jarZipFileName );
@@ -426,9 +424,9 @@ public abstract class AbstractRegPopulator implements JposRegPopulator
 	                    
 						if( entryName.endsWith( fileName ) )
 	                    {
-							is = new BufferedInputStream( zipFile.
+	                       is = new BufferedInputStream( zipFile.
 				                        	 getInputStream( zipEntry ) );
-	                        break;
+	                       return is;
 	                    }
 	                }
 	            }
@@ -443,8 +441,6 @@ public abstract class AbstractRegPopulator implements JposRegPopulator
             	tracer.println( "findInJarZipFiles: Exception.message=" +
             					e.getMessage() );
             }
-
-            if( is != null ) break;
         }
 
         return is;

--- a/src/main/java/jpos/config/simple/AbstractRegPopulator.java
+++ b/src/main/java/jpos/config/simple/AbstractRegPopulator.java
@@ -412,22 +412,31 @@ public abstract class AbstractRegPopulator implements JposRegPopulator
         {
             String jarZipFileName = jarZipFilesList.get( i );
 
-            try (ZipFile zipFile = new ZipFile( jarZipFileName ))
+            try
             {
-                Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
+            	ZipFile zipFile = new ZipFile( jarZipFileName );
+            	try {
+                
+            		Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
 
-                while( zipEntries.hasMoreElements() )
-                {
-                    ZipEntry zipEntry = zipEntries.nextElement();
-                    String entryName = zipEntry.getName();
-                    
-					if( entryName.endsWith( fileName ) )
-                    {
-                        is = new BufferedInputStream( zipFile.
-                        	 getInputStream( zipEntry ) );
-                        break;
-                    }
-                }
+	                while( zipEntries.hasMoreElements() )
+	                {
+	                    ZipEntry zipEntry = zipEntries.nextElement();
+	                    String entryName = zipEntry.getName();
+	                    
+						if( entryName.endsWith( fileName ) )
+	                    {
+							is = new BufferedInputStream( zipFile.
+				                        	 getInputStream( zipEntry ) );
+	                        break;
+	                    }
+	                }
+	            }
+            	finally {
+            		if (is == null) {
+            			zipFile.close();
+            		}
+            	}
             }
             catch( Exception e ) 
             {

--- a/src/main/java/jpos/config/simple/xml/JavaxRegPopulator.java
+++ b/src/main/java/jpos/config/simple/xml/JavaxRegPopulator.java
@@ -133,7 +133,7 @@ public class JavaxRegPopulator
 
     @Override
     public void load() {
-        try (InputStream is = isPopulatorFileDefined() ? new FileInputStream(DEFAULT_XML_FILE_NAME) : getPopulatorFileIS()) {
+        try (InputStream is = isPopulatorFileDefined() ? getPopulatorFileIS() : new FileInputStream(DEFAULT_XML_FILE_NAME) ) {
             load(is);
         } catch (Exception e) {
             tracer.println("Error while loading populator file Exception.message: " + e.getMessage());

--- a/src/test/java/jpos/config/simple/xml/JavaxRegPopulatorTestCase.java
+++ b/src/test/java/jpos/config/simple/xml/JavaxRegPopulatorTestCase.java
@@ -317,7 +317,7 @@ public class JavaxRegPopulatorTestCase extends AbstractRegPopulatorTestCase
 
         javaxRegPopulator.load();
 
-        assertTrue("Default jpos.xml is not found",
+        assertTrue("Custom XML populator file not found",
                 javaxRegPopulator.getLastLoadException() instanceof FileNotFoundException);
 
         restorePropFile();
@@ -384,7 +384,7 @@ public class JavaxRegPopulatorTestCase extends AbstractRegPopulatorTestCase
         }
         catch( Exception e )
         {
-            assertTrue( "Got unexpected Exception from XercesRegPopulator.save method with message = " + e.getMessage(), true );
+            fail( "Unexpected exception message = " + e.getMessage() );
         }
 
         restorePropFile();


### PR DESCRIPTION
Currently there are following issues with JCL v4+:

- JCL has reversed logic for populator value in properties file.
- JCL cannot open found JAR resource files

## Reversed Populator Logic

This line is incorrect:
``` java
try (InputStream is = isPopulatorFileDefined() ? new FileInputStream(DEFAULT_XML_FILE_NAME) : getPopulatorFileIS())
``` 

Instead of loading the defined populator file it loads default and vice versa.

## JCL Cannot Load Found JAR Resource Files

JCL v4 uses `try-with-resources` in `findFileInJarZipFiles` method:

``` java
try (ZipFile zipFile = new ZipFile( jarZipFileName ))
```

As result this statement is also closing returned `zipEntry` file handle too.

To correct this `try` and `finally` were used instead.

NB: It seems my Eclipse settings have screwed whitespace with tabs a little bit.